### PR TITLE
Development

### DIFF
--- a/src/app/about/about-routing.module.ts
+++ b/src/app/about/about-routing.module.ts
@@ -1,0 +1,20 @@
+import { NgModule } from '@angular/core';
+import { Routes, RouterModule } from '@angular/router';
+
+import { AboutComponent } from "./about.component";
+
+const routes: Routes = [
+        {
+            path: '',
+            component: AboutComponent
+        }
+];
+@NgModule({
+    imports: [
+        RouterModule.forChild(routes)
+    ],
+    exports: [
+        RouterModule 
+    ]
+})
+export class AboutRoutingModule {}

--- a/src/app/about/about.component.html
+++ b/src/app/about/about.component.html
@@ -1,0 +1,3 @@
+<p>
+  about works!
+</p>

--- a/src/app/about/about.component.spec.ts
+++ b/src/app/about/about.component.spec.ts
@@ -1,0 +1,25 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { AboutComponent } from './about.component';
+
+describe('AboutComponent', () => {
+  let component: AboutComponent;
+  let fixture: ComponentFixture<AboutComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [ AboutComponent ]
+    })
+    .compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(AboutComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should be created', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/about/about.component.ts
+++ b/src/app/about/about.component.ts
@@ -1,0 +1,15 @@
+import { Component, OnInit } from '@angular/core';
+
+@Component({
+  selector: 'nab-about',
+  templateUrl: './about.component.html',
+  styles: []
+})
+export class AboutComponent implements OnInit {
+
+  constructor() { }
+
+  ngOnInit() {
+  }
+
+}

--- a/src/app/about/about.module.ts
+++ b/src/app/about/about.module.ts
@@ -1,0 +1,14 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+
+import { AboutComponent } from './about.component';
+import { AboutRoutingModule } from "./about-routing.module";
+
+@NgModule({
+  imports: [
+    CommonModule,
+    AboutRoutingModule
+  ],
+  declarations: [AboutComponent]
+})
+export class AboutModule { }

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -3,6 +3,7 @@ import { NgModule } from '@angular/core';
 
 import { CoreModule } from "./core/core.module";
 import { ShellComponent } from "./core/shell/shell.component";
+import { CoreRoutingModule } from "./core/core-routing.module";
 
 @NgModule({
   declarations: [

--- a/src/app/core/core-routing.module.ts
+++ b/src/app/core/core-routing.module.ts
@@ -1,0 +1,23 @@
+import { NgModule } from '@angular/core';
+import { Routes, RouterModule } from '@angular/router';
+
+const routes: Routes = [
+        {
+            path: '',
+            loadChildren: './../home/home.module#HomeModule'
+        },
+        {
+            path: 'about',
+            loadChildren: '../about/about.module#AboutModule'
+        }
+];
+@NgModule({
+    imports: [
+        RouterModule.forRoot(routes) // configuración para el módulo raíz
+                                     // RouterModule tambien nos servira para routerLink en main-content
+    ],
+    exports: [
+        RouterModule // se importará desde el módulo padre
+    ]
+})
+export class CoreRoutingModule {}

--- a/src/app/core/core.module.ts
+++ b/src/app/core/core.module.ts
@@ -1,11 +1,17 @@
 import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { ShellComponent } from './shell/shell.component';
+import { MainContentComponent } from './shell/main-content/main-content.component';
+import { TopBarComponent } from './shell/top-bar/top-bar.component';
 
 @NgModule({
   imports: [
     CommonModule
   ],
-  declarations: [ShellComponent]
+  declarations: [
+    ShellComponent, 
+    MainContentComponent, // no exportamos, se usa solo dentro de shell.
+    TopBarComponent // no exportamos, se usa solo dentro de shell.
+  ]
 })
 export class CoreModule { }

--- a/src/app/core/core.module.ts
+++ b/src/app/core/core.module.ts
@@ -1,17 +1,24 @@
 import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
+
 import { ShellComponent } from './shell/shell.component';
 import { MainContentComponent } from './shell/main-content/main-content.component';
 import { TopBarComponent } from './shell/top-bar/top-bar.component';
+import { CoreRoutingModule } from "./core-routing.module";
+
 
 @NgModule({
   imports: [
-    CommonModule
+    CommonModule,
+    CoreRoutingModule
   ],
+  providers:[],
   declarations: [
     ShellComponent, 
     MainContentComponent, // no exportamos, se usa solo dentro de shell.
     TopBarComponent // no exportamos, se usa solo dentro de shell.
-  ]
+  ]/*,
+  exports: [ShellComponent]*/
+  
 })
 export class CoreModule { }

--- a/src/app/core/shell/main-content/main-content.component.html
+++ b/src/app/core/shell/main-content/main-content.component.html
@@ -1,0 +1,3 @@
+<p>
+  main-content works!
+</p>

--- a/src/app/core/shell/main-content/main-content.component.html
+++ b/src/app/core/shell/main-content/main-content.component.html
@@ -1,3 +1,1 @@
-<p>
-  main-content works!
-</p>
+<router-outlet></router-outlet>

--- a/src/app/core/shell/main-content/main-content.component.spec.ts
+++ b/src/app/core/shell/main-content/main-content.component.spec.ts
@@ -1,0 +1,25 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { MainContentComponent } from './main-content.component';
+
+describe('MainContentComponent', () => {
+  let component: MainContentComponent;
+  let fixture: ComponentFixture<MainContentComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [ MainContentComponent ]
+    })
+    .compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(MainContentComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should be created', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/core/shell/main-content/main-content.component.ts
+++ b/src/app/core/shell/main-content/main-content.component.ts
@@ -1,0 +1,15 @@
+import { Component, OnInit } from '@angular/core';
+
+@Component({
+  selector: 'nab-main-content',
+  templateUrl: './main-content.component.html',
+  styles: []
+})
+export class MainContentComponent implements OnInit {
+
+  constructor() { }
+
+  ngOnInit() {
+  }
+
+}

--- a/src/app/core/shell/shell.component.html
+++ b/src/app/core/shell/shell.component.html
@@ -1,3 +1,6 @@
-<p>
-  shell works!
-</p>
+<section>
+  <nab-top-bar></nab-top-bar>
+</section>
+<section>
+  <nab-main-content></nab-main-content>
+</section>

--- a/src/app/core/shell/top-bar/top-bar.component.html
+++ b/src/app/core/shell/top-bar/top-bar.component.html
@@ -1,4 +1,4 @@
 <nav>
-  <a href="">Home</a>
-  <a href="">About</a>
+  <a [routerLink]="['']">Home</a>
+  <a [routerLink]="['about']">About</a>
 </nav>

--- a/src/app/core/shell/top-bar/top-bar.component.html
+++ b/src/app/core/shell/top-bar/top-bar.component.html
@@ -1,0 +1,4 @@
+<nav>
+  <a href="">Home</a>
+  <a href="">About</a>
+</nav>

--- a/src/app/core/shell/top-bar/top-bar.component.spec.ts
+++ b/src/app/core/shell/top-bar/top-bar.component.spec.ts
@@ -1,0 +1,25 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { TopBarComponent } from './top-bar.component';
+
+describe('TopBarComponent', () => {
+  let component: TopBarComponent;
+  let fixture: ComponentFixture<TopBarComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [ TopBarComponent ]
+    })
+    .compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(TopBarComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should be created', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/core/shell/top-bar/top-bar.component.ts
+++ b/src/app/core/shell/top-bar/top-bar.component.ts
@@ -1,0 +1,15 @@
+import { Component, OnInit } from '@angular/core';
+
+@Component({
+  selector: 'nab-top-bar',
+  templateUrl: './top-bar.component.html',
+  styles: []
+})
+export class TopBarComponent implements OnInit {
+
+  constructor() { }
+
+  ngOnInit() {
+  }
+
+}

--- a/src/app/home/home-routing.module.ts
+++ b/src/app/home/home-routing.module.ts
@@ -1,0 +1,20 @@
+import { NgModule } from '@angular/core';
+import { Routes, RouterModule } from '@angular/router';
+
+import { HomeComponent } from "./home.component";
+
+const routes: Routes = [
+        {
+            path: '',
+            component: HomeComponent
+        }
+];
+@NgModule({
+    imports: [
+        RouterModule.forChild(routes)
+    ],
+    exports: [
+        RouterModule 
+    ]
+})
+export class HomeRoutingModule {}

--- a/src/app/home/home.component.html
+++ b/src/app/home/home.component.html
@@ -1,0 +1,3 @@
+<p>
+  home works!
+</p>

--- a/src/app/home/home.component.spec.ts
+++ b/src/app/home/home.component.spec.ts
@@ -1,0 +1,25 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { HomeComponent } from './home.component';
+
+describe('HomeComponent', () => {
+  let component: HomeComponent;
+  let fixture: ComponentFixture<HomeComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [ HomeComponent ]
+    })
+    .compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(HomeComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should be created', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/home/home.component.ts
+++ b/src/app/home/home.component.ts
@@ -1,0 +1,15 @@
+import { Component, OnInit } from '@angular/core';
+
+@Component({
+  selector: 'nab-home',
+  templateUrl: './home.component.html',
+  styles: []
+})
+export class HomeComponent implements OnInit {
+
+  constructor() { }
+
+  ngOnInit() {
+  }
+
+}

--- a/src/app/home/home.module.ts
+++ b/src/app/home/home.module.ts
@@ -1,0 +1,14 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+
+import { HomeComponent } from './home.component';
+import { HomeRoutingModule } from "./home-routing.module";
+
+@NgModule({
+  imports: [
+    CommonModule,
+    HomeRoutingModule
+  ],
+  declarations: [HomeComponent]
+})
+export class HomeModule { }


### PR DESCRIPTION
             path
             component: HomeComponent 
Si trabajamos de esta forma webpack empaqueta y trae el componente.

En 
            loadChildren No se pone una referencia concreta al componente, sino un string que sirve de indicio para que se cargue de manera dinamica el componente,
--------------------------------------------------------------------------------------------------------------------
Con lazyloading no tengo que importar los modulos home y about en core para routear ! lazy loading lo busca por medio del string, por ejemplo : './../home/home.module#HomeModule'